### PR TITLE
Use actual image type for mimetype instead of file extension.

### DIFF
--- a/flask_images/core.py
+++ b/flask_images/core.py
@@ -355,9 +355,8 @@ class Images(object):
         quality = int(quality) if quality else 75
         format = query.get('format', '').lower()
         if not format:
-            img = Image.open(path)
-            format = img.format.lower()
-            img.close()
+            with Image.open(path) as img:
+                format = img.format.lower()
         has_version = 'version' in query
         use_cache = query.get('cache', True)
         enlarge = query.get('enlarge', False)


### PR DESCRIPTION
Instead of relying on the file extension of the image file, get the file type from the file itself. This way files without extensions will also be able to be resized.
This should fix cephalo-ai/cassoulet#267